### PR TITLE
Add feature to download PMIDs generated via PubMed search 

### DIFF
--- a/src/pubmed2pdf/cli.py
+++ b/src/pubmed2pdf/cli.py
@@ -31,7 +31,8 @@ def main():
 )
 @click.option('--maxtries', help='Max number of tries per article', default=3, type=int, show_default=True)
 @click.option('-v', '--verbose', help='Log everything', is_flag=True)
-def pdf(pmids, pmidsfile, out, errors, exported, maxtries, verbose):
+@click.option('--search', help='Search terms for use in PubMed', type=str)
+def pdf(pmids, pmidsfile, out, errors, exported, maxtries, verbose, search):
     """Get PDFs from PubMed idenfiers."""
 
     if verbose:
@@ -41,8 +42,8 @@ def pdf(pmids, pmidsfile, out, errors, exported, maxtries, verbose):
         logger.setLevel(logging.INFO)
 
     # Checking arguments
-    if not pmids and not pmidsfile:
-        click.echo("Error: One of the two arguments '--pmids' or '--pmidsfile' must be used. Exiting...")
+    if not pmids and not pmidsfile and not search:
+        click.echo("Error: One of the arguments '--pmids' or '--pmidsfile' or '--search' must be used. Exiting...")
         exit(1)
     if pmids and pmidsfile:
         click.echo("Error: --pmids and --pmidsfile cannot be used together. Please select only one. Exiting...")
@@ -70,9 +71,16 @@ def pdf(pmids, pmidsfile, out, errors, exported, maxtries, verbose):
                             'Chrome/56.0.2924.87 ' \
                             'Safari/537.36'
 
+
     if pmids:
         # Split by comma the pubmeds
         pmids = [i.strip() for i in pmids.split(",")]
+        names = pmids
+    elif search:
+    	# Get list of  pubmeds from search
+        pmids = search_pubmed(search)
+        print(pmids)
+        #pmids = [i.strip() for i in pmids.split(",")]
         names = pmids
     else:
         # Read file and get the pubmeds

--- a/src/pubmed2pdf/utils.py
+++ b/src/pubmed2pdf/utils.py
@@ -71,21 +71,13 @@ def fetch(pmid, finders, name, headers, errorPmids, output_dir):
         logger.debug("** Reprint {0} could not be fetched with the current finders.".format(pmid))
         errorPmids.write("{}\t{}\n".format(pmid, name))
 
-# def search_pubmed(query):
-#     search_url = f"https://pubmed.ncbi.nlm.nih.gov/?term={query}"
-#     response = requests.get(search_url)
-#     if response.status_code == 200:
-#         pmids = re.findall(r'data-pmid="(\d+)"', response.text)
-#         return pmids
-#     else:
-#         logger.error(f"Failed to search PubMed for query: {query}")
-#         return []
 
 def search_pubmed(query):
     handle = Entrez.esearch(db="pubmed", term=query, retmax=100)
     record = Entrez.read(handle)
     handle.close()
     return record["IdList"]
+
 
 def acsPublications(req, soup, headers):
     possibleLinks = [

--- a/src/pubmed2pdf/utils.py
+++ b/src/pubmed2pdf/utils.py
@@ -10,6 +10,8 @@ import urllib
 import requests
 from bs4 import BeautifulSoup
 
+from Bio import Entrez
+
 logger = logging.getLogger(__name__)
 
 
@@ -69,6 +71,21 @@ def fetch(pmid, finders, name, headers, errorPmids, output_dir):
         logger.debug("** Reprint {0} could not be fetched with the current finders.".format(pmid))
         errorPmids.write("{}\t{}\n".format(pmid, name))
 
+# def search_pubmed(query):
+#     search_url = f"https://pubmed.ncbi.nlm.nih.gov/?term={query}"
+#     response = requests.get(search_url)
+#     if response.status_code == 200:
+#         pmids = re.findall(r'data-pmid="(\d+)"', response.text)
+#         return pmids
+#     else:
+#         logger.error(f"Failed to search PubMed for query: {query}")
+#         return []
+
+def search_pubmed(query):
+    handle = Entrez.esearch(db="pubmed", term=query, retmax=100)
+    record = Entrez.read(handle)
+    handle.close()
+    return record["IdList"]
 
 def acsPublications(req, soup, headers):
     possibleLinks = [


### PR DESCRIPTION
Adds a flag `--search` that allows direct query of PubMed from the command line. The resulting PMIDs are then passed to existing code for download. 
- `--search` flag optionally replaces `--pmids` and `--pmidsfile`
- Takes search terms as string 
- Requires `Entrez` from the `Bio` library to access NCBI search 

Example executable: `python3 -m pubmed2pdf pdf --search "ovule count flower"`

By using `--search`, users can directly download the PDFs corresponding to their inquiry rather than externally generating a list of PMIDs through a separate step. 